### PR TITLE
qemu: add installation script

### DIFF
--- a/install_qemu
+++ b/install_qemu
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+QEMU_DIR = $(PWD)/emulator
+QEMU_SRC_DIR = ${QEMU_DIR}/qemu-${QEMU_VER}
+QEMU_OUT_DIR = ${QEMU_DIR}/out
+QEMU_BIN_DIR = ${QEMU_OUT_DIR}/bin
+
+QEMU_VER ?= 7.0.0
+QEMU_TARBALL = qemu-${QEMU_VER}.tar.xz
+
+QEMU_TARGET ?= riscv32-softmmu,riscv32-linux-user
+
+echo "QEMU VERISION: ${QEMU_VER}"
+echo "QEMU DIR: ${QEMU_DIR}"
+echo "QEMU SRC DIR: ${QEMU_SRC_DIR}"
+echo "QEMU OUT DIR: ${QEMU_OUT_DIR}"
+echo "QEMU BIN DIR: ${QEMU_BIN_DIR}"
+echo "QEMU TAREGT: ${QEMU_TARGET}"
+
+# install prerequisite
+sudo apt-get install libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
+
+if [ ! -d "${QEMU_DIR}" ]; then
+	mkdir -p ${QEMU_DIR}
+fi
+
+# to qemu build root directory
+cd ${QEMU_DIR}
+
+# download qemu tarball
+wget https://download.qemu.org/${QEMU_TARBALL}
+
+# untar
+tar xvJf ${QEMU_TARBALL}
+
+# remove tarball
+rm ${QEMU_TARBALL}
+
+# to qemu source directory for building
+cd ${QEMU_SRC_DIR}
+
+# build
+./configure --target-list=${QEMU_TARGET} --prefix=${QEMU_OUT_DIR} \
+	&& make \
+	&& make install \
+	&& echo "PATH=$${PATH}:${QEMU_BIN_DIR}


### PR DESCRIPTION
add installation script for qemu
default qemu version is 7.0.0
default toolchain version is riscv32

Signed-off-by: tim90721 <tim90721@gmail.com>